### PR TITLE
Update sensor.py minimal fix for 2025.1 deprecation of const.TEMP_CEL…

### DIFF
--- a/custom_components/ultimaker/sensor.py
+++ b/custom_components/ultimaker/sensor.py
@@ -36,8 +36,9 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_SCAN_INTERVAL,
     CONF_SENSORS,
-    TEMP_CELSIUS,
+    UnitOfTemperature,
 )
+TEMP_CELSIUS = UnitOfTemperature.CELSIUS
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType, StateType


### PR DESCRIPTION
HA 2025.1 did away with const.TEMP_CELSIUS, it is now in UnitOfTemperature.CELSIUS. This is a minimal change to get it back to working; naturally one could also change all the references to TEMP_CELSIUS but I just wanted a minimal change to get back to working for this.