### PR TITLE
Pr fix for ha 2025.05 which removes hass.helpers and prevents the integration from starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/hacs/integration)
 # Home Assistant Ultimaker printers
 
+Clews fork
+
 ![sensors](https://github.com/jellespijker/home-assistant-ultimaker/raw/main/resources/home-assistant-um.png)
 
 Adds support for the following ultimaker printer sensors:

--- a/custom_components/ultimaker/__init__.py
+++ b/custom_components/ultimaker/__init__.py
@@ -1,12 +1,15 @@
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.discovery import load_platform
+
 """Ultimaker printer integration"""
 DOMAIN = "ultimaker"
 
 
-def setup(hass, config):
+def setup(hass: HomeAssistant, config):
     """Your controller/hub specific code."""
     # Data that you want to share with your platforms
     hass.data[DOMAIN] = {"x": 0}
 
-    hass.helpers.discovery.load_platform("sensor", DOMAIN, {}, config)
+    load_platform(hass, "sensor", DOMAIN, {}, config)
 
     return True

--- a/custom_components/ultimaker/manifest.json
+++ b/custom_components/ultimaker/manifest.json
@@ -6,5 +6,5 @@
   "dependencies": [],
   "codeowners": ["@jellespijker", "@clews"],
   "requirements": [],
-  "version": "0.1.5"
+  "version": "0.1.6"
 }

--- a/custom_components/ultimaker/manifest.json
+++ b/custom_components/ultimaker/manifest.json
@@ -6,5 +6,5 @@
   "dependencies": [],
   "codeowners": ["@jellespijker"],
   "requirements": [],
-  "version": "0.1.4"
+  "version": "0.1.5"
 }

--- a/custom_components/ultimaker/manifest.json
+++ b/custom_components/ultimaker/manifest.json
@@ -1,10 +1,10 @@
 {
   "domain": "ultimaker",
   "name": "Ultimaker",
-  "documentation": "https://github.com/jellespijker/home-assistant-ultimaker",
-  "issue_tracker": "https://github.com/jellespijker/home-assistant-ultimaker/issues",
+  "documentation": "https://github.com/clews/home-assistant-ultimaker",
+  "issue_tracker": "https://github.com/clews/home-assistant-ultimaker/issues",
   "dependencies": [],
-  "codeowners": ["@jellespijker"],
+  "codeowners": ["@jellespijker", "@clews"],
   "requirements": [],
   "version": "0.1.5"
 }

--- a/custom_components/ultimaker/sensor.py
+++ b/custom_components/ultimaker/sensor.py
@@ -24,20 +24,16 @@ sensor:
 import asyncio
 import logging
 from datetime import datetime, timedelta
-from typing import Any, Dict, Optional
 from pprint import pprint
+from typing import Any, Dict, Optional
 
 import aiohttp
 import async_timeout
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_NAME,
-    CONF_SCAN_INTERVAL,
-    CONF_SENSORS,
-)
+from homeassistant.const import (CONF_HOST, CONF_NAME, CONF_SCAN_INTERVAL,
+                                 CONF_SENSORS)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType, StateType

--- a/custom_components/ultimaker/sensor.py
+++ b/custom_components/ultimaker/sensor.py
@@ -64,6 +64,7 @@ SENSOR_TYPES = {
         TEMP_CELSIUS,
         "mdi:thermometer",
     ],
+    "hotend_1_serial": ["Hotend 1 serial number", "", "mdi:serial"],
     "hotend_1_id": ["Hotend 1 id", "", "mdi:printer-3d-nozzle-outline"],
     "hotend_2_temperature": ["Hotend 2 temperature", TEMP_CELSIUS, "mdi:thermometer"],
     "hotend_2_temperature_target": [
@@ -71,6 +72,8 @@ SENSOR_TYPES = {
         TEMP_CELSIUS,
         "mdi:thermometer",
     ],
+    "hotend_2_statistics_material": ["Hotend 2 statistics material", "", "mdi:statistics"],
+    "hotend_2_serial": ["Hotend 2 serial number", "", "mdi:serial"],
     "hotend_2_id": ["Hotend 2 id", "", "mdi:printer-3d-nozzle-outline"],
 }
 

--- a/info.md
+++ b/info.md
@@ -48,18 +48,31 @@ sensor:
     scan_interval: 10  # optional, default 10
     decimal: 2  # optional, default 2 rounds the sensor values
     sensors:
-      - status
-      - state
-      - progress
-      - bed_type
-      - bed_temperature
-      - bed_temperature_target
-      - hotend_1_id
-      - hotend_1_temperature
-      - hotend_1_temperature_target
-      - hotend_2_id
-      - hotend_2_temperature
-      - hotend_2_temperature_target
+      - status  # optional
+      - state  # optional
+      - progress  # optional
+      - time_elapsed # optional
+      - time_estimated # optional
+      - time_total # optional
+      - bed_type  # optional
+      - bed_temperature  # optional
+      - bed_temperature_target  # optional
+      - hotend_1_id  # optional
+      - hotend_1_temperature  # optional
+      - hotend_1_temperature_target  # optional
+      - hotend_1_statistics_material_extruded # optional
+      - hotend_1_statistics_prints_since_cleaned # optional
+      - hotend_1_statistics_max_temperature_exposed # optional
+      - hotend_1_statistics_time_spent_hot # optional
+      - hotend_1_serial # optional
+      - hotend_2_id  # optional
+      - hotend_2_temperature  # optional
+      - hotend_2_temperature_target  # optional
+      - hotend_2_statistics_material_extruded # optional
+      - hotend_2_statistics_prints_since_cleaned # optional
+      - hotend_1_statistics_max_temperature_exposed # optional
+      - hotend_1_statistics_time_spent_hot # optional
+      - hotend_2_serial # optional
 ```
 
 ### Camera

--- a/info.md
+++ b/info.md
@@ -1,6 +1,8 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 # Home Assistant Ultimaker printers
 
+Personal version with new sensors
+
 ![sensors](https://github.com/jellespijker/home-assistant-ultimaker/raw/main/resources/home-assistant-um.png)
 
 Adds support for the following ultimaker printer sensors:


### PR DESCRIPTION
Fix for HA release 2025.5 which removes hass.helpers (see https://github.com/home-assistant/core/pull/143514)

My IDE did an isort on imports.

Fixes #23 
