### PR TITLE
Fix for HA release 2025.5 which removes hass.helpers (see home-assist…

### DIFF
--- a/custom_components/ultimaker/__init__.py
+++ b/custom_components/ultimaker/__init__.py
@@ -1,12 +1,15 @@
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.discovery import load_platform
+
 """Ultimaker printer integration"""
 DOMAIN = "ultimaker"
 
 
-def setup(hass, config):
+def setup(hass: HomeAssistant, config):
     """Your controller/hub specific code."""
     # Data that you want to share with your platforms
     hass.data[DOMAIN] = {"x": 0}
 
-    hass.helpers.discovery.load_platform("sensor", DOMAIN, {}, config)
+    load_platform("sensor", DOMAIN, {}, config)
 
     return True


### PR DESCRIPTION
Fix for HA release 2025.5 which removes hass.helpers (see home-assistant/core#143514)

Fixes #23 
