### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/ultimaker/__init__.py
+++ b/custom_components/ultimaker/__init__.py
@@ -10,6 +10,6 @@ def setup(hass: HomeAssistant, config):
     # Data that you want to share with your platforms
     hass.data[DOMAIN] = {"x": 0}
 
-    load_platform("sensor", DOMAIN, {}, config)
+    load_platform(hass, "sensor", DOMAIN, {}, config)
 
     return True


### PR DESCRIPTION
Still had an error:
TypeError: load_platform() missing 1 required positional argument: 'hass_config'

Added 'hass' as first argument for load_platform() to fix the problem for me. Got the idea from this post: https://community.home-assistant.io/t/integrate-with-opensprinkler/18142/63